### PR TITLE
Adding default mapping for mix.css() and mix.postCss()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,12 @@ const MixGlob = (function () {
         stylus: {
             ext: 'css'
         },
+        css: {
+            ext: 'css'
+        },
+        postCss: {
+            ext: 'css'
+        },
         react: {
             ext: 'js'
         },


### PR DESCRIPTION
See issue #52.