### PR TITLE
Security update for package globby

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "colors": "^1.3.3",
     "flat-cache": "^2.0.1",
-    "globby": "^9.2.0",
+    "globby": "^13.1.1",
     "micromatch": "^3.1.10"
   },
   "devDependencies": {


### PR DESCRIPTION
Local dependabot alert for "Regular expression denial of service in glob-parent" due to an old version of glob-parent down the dependency chain. Updating `globby` updates glob-parent to a safe version. Will test this locally today, but let me know if there is something specific I can run. 